### PR TITLE
Update collector

### DIFF
--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -54,15 +54,16 @@ func doHTTPGet(c *Client, body []byte) ([]byte, error) {
 	return body, nil
 }
 
-func (c *Client) GetHearthbeat() (PingHBResponse, error) {
+func (c *Client) GetHeartbeat() (PingHBResponse, error) {
 	r := PingHBResponse{}
 	bodyBytes, err := doHTTPGet(c, nil)
-
 	if err != nil {
 		return r, err
 	}
-	err = json.Unmarshal(bodyBytes, &r)
+
+	err = json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(&r)
 	if err != nil {
+		log.Infof("errorrororor %v", err)
 		return r, err
 	}
 	return r, nil

--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -63,7 +63,6 @@ func (c *Client) GetHeartbeat() (PingHBResponse, error) {
 
 	err = json.NewDecoder(bytes.NewReader(bodyBytes)).Decode(&r)
 	if err != nil {
-		log.Infof("errorrororor %v", err)
 		return r, err
 	}
 	return r, nil

--- a/pkg/ping/ping_test.go
+++ b/pkg/ping/ping_test.go
@@ -46,7 +46,7 @@ func TestClient_GetPingAccessHearthbeat(t *testing.T) {
 				Reply(200).
 				BodyString(string(fixture))
 
-			gotRaw, err := pingClient.GetHearthbeat()
+			gotRaw, err := pingClient.GetHeartbeat()
 			fmt.Println(gotRaw)
 			got := gotRaw.Items[0].CPULoad
 

--- a/pkg/prom/collector.go
+++ b/pkg/prom/collector.go
@@ -72,9 +72,11 @@ func strToFloat64(arg string) (float64, error) {
 	regex := regexp.MustCompile(`(\d*[.,]?\d+)\s?(\w+)?`)
 	result := regex.FindAllStringSubmatch(arg, -1)
 
-	// Sometimes the api returns values like N/A. If this happens, return an error and do not render the metric from the result
+	// Sometimes the api returns values like N/A.
+	// If this happens,
+	// print a DEBUG and do not render the metric from the result
 	if len(result) == 0 {
-		log.Errorf("Unexpected return value from API: %s", arg)
+		log.Debugf("Unexpected return value from API: %s", arg)
 		return 0, fmt.Errorf("Unexpected return value from API: %s", arg)
 	}
 
@@ -104,9 +106,9 @@ func setUpMetric(c *pingCollector, up float64, ch chan<- prometheus.Metric) {
 func (c *pingCollector) Collect(ch chan<- prometheus.Metric) {
 	var value float64 = 0
 
-	heartbeat, err := c.client.GetHearthbeat()
+	heartbeat, err := c.client.GetHeartbeat()
 	if err != nil {
-		setUpMetric(c, 0, ch)
+		// setUpMetric(c, 0, ch)
 		log.Errorf("Received invalid status code from RPC call: %v\n", err)
 	}
 


### PR DESCRIPTION
- update collector to use json encoder instead of json unmarshall
- this is because the heartbeat endpoint sometimes return OK and this breaks json unmarshall